### PR TITLE
Add Prometheus config alerting: configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ prometheus_config_scrape_configs:
   #   consul_sd_configs:
   #     - server: "localhost:8500"
 
+# Allow Prometheus to disover alert managers
+prometheus_config_alerting:
+  alertmanagers:
+  - static_configs:
+    - targets:
+      - localhost:9093
 
 prometheus_config__file: "{{ prometheus_config_dir }}/prometheus.yml"
 # Prometheus configuration file name.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -56,6 +56,7 @@ prometheus_rules:
         summary: 'Instance [[ $labels.instance ]] down'
         description: '[[ $labels.instance ]] of job [[ $labels.job ]] has been down for more than 10 seconds.'
 
+# Allow Prometheus to disover alert managers
 prometheus_config_scrape_configs:
   # - job_name: 'prometheus'
   #   honor_labels: true
@@ -69,6 +70,13 @@ prometheus_config_scrape_configs:
   # - job_name: 'consul-services'
   #   consul_sd_configs:
   #     - server: "localhost:8500"
+
+# Allow Prometheus to disover alert managers
+prometheus_config_alerting:
+  alertmanagers:
+  - static_configs:
+    - targets:
+      - localhost:9093
 
 prometheus_config__file: "{{ prometheus_config_dir }}/prometheus.yml"
 # Prometheus configuration file name.

--- a/templates/prometheus.yml.j2
+++ b/templates/prometheus.yml.j2
@@ -15,3 +15,7 @@
 {% if prometheus_config_scrape_configs is not none and prometheus_config_scrape_configs | length > 0 %}
 {{ {'scrape_configs': prometheus_config_scrape_configs} | to_nice_yaml }}
 {% endif %}
+
+{% if prometheus_config_alerting is not none and prometheus_config_alerting | length > 0 %}
+{{ {'alerting': prometheus_config_alerting} | to_nice_yaml }}
+{% endif %}


### PR DESCRIPTION
cc @madeinoz67

Related: https://github.com/ernestas-poskus/ansible-prometheus/issues/37

Looks like I have missed adding new `alerting:` variable to Prometheus yml config to discover alert managers when was migrating to Prometheus 2.0.

![screenshot from 2017-11-24 11-33-11](https://user-images.githubusercontent.com/4499780/33204252-a3cf12a0-d10b-11e7-801f-fc8e0057c337.png)


This should solve your problem.