### PR TITLE
Allow alertmanager variables in alertmanager receivers config

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,10 @@ prometheus_alert_manager_config_route:
 # already critical.
 prometheus_alert_manager_config_inhibit_rules:
 
+# Prometheus alert manager receivers
+# since Ansible uses double curly braces as well as Prometheus for
+# variable interpolation in receivers use double square brackets,
+# those will be replaced to curly braces.
 prometheus_alert_manager_config_receivers:
   - name: 'default-pager'
     pagerduty_configs:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -279,6 +279,10 @@ prometheus_alert_manager_config_route:
 # already critical.
 prometheus_alert_manager_config_inhibit_rules:
 
+# Prometheus alert manager receivers
+# since Ansible uses double curly braces as well as Prometheus for
+# variable interpolation in receivers use double square brackets,
+# those will be replaced to curly braces.
 prometheus_alert_manager_config_receivers:
   - name: 'default-pager'
     pagerduty_configs:

--- a/tasks/install-alert_manager.yml
+++ b/tasks/install-alert_manager.yml
@@ -13,6 +13,7 @@
     dest: "{{ prometheus_alert_manager_config_dir }}/alertmanager.yml"
     owner: "{{ prometheus_owner }}"
     group: "{{ prometheus_group }}"
+    validate: "{{ prometheus_install_dir }}/{{ prometheus_alert_manager_archive }}/amtool check-config %s"
   notify:
     restart alertmanager
 

--- a/templates/alertmanager.yml.j2
+++ b/templates/alertmanager.yml.j2
@@ -19,5 +19,5 @@
 {% endif %}
 
 {% if prometheus_alert_manager_config_receivers is not none %}
-{{ {'receivers': prometheus_alert_manager_config_receivers} | to_nice_yaml }}
+{{ {'receivers': prometheus_alert_manager_config_receivers} | to_json | regex_replace('\\[\\[', '{{') | regex_replace('\\]\\]', '}}') | from_json | to_nice_yaml }}
 {% endif %}

--- a/tests/playbook.yml
+++ b/tests/playbook.yml
@@ -7,3 +7,16 @@
       prometheus_node_exporter_install: true
       prometheus_alert_manager_install: true
       prometheus_push_gateway_install: true
+      prometheus_alert_manager_config_global:
+        slack_api_url: 'https://github.com/ernestas-poskus/ansible-prometheus/pull/42'
+      prometheus_alert_manager_config_receivers:
+        - name: 'default-pager'
+          pagerduty_configs:
+          - service_key: '<team-X-key>'
+        - name: 'default'
+          slack_configs:
+            - channel: '#alerts'
+              username: 'Alert-Manager'
+              title: "[[ range $Alerts ]][[ $Annotations.summary ]]\n[[ end ]]"
+              text: "[[ range $Alerts ]][[ $Annotations.description ]]\n[[ end ]]"
+              send_resolved: true

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -38,3 +38,8 @@
     - shell: "systemctl status pushgateway | grep -i running"
       register: status
       failed_when: status.rc != 0
+
+    - name: Check alertmanager receivers configuration is valid
+      command: cat /etc/prometheus/alertmanager/alertmanager.yml
+      register: command_result
+      failed_when: "'[[ range $Alerts ]][[ $Annotations.summary ]]' in command_result.stdout"


### PR DESCRIPTION
Related: https://github.com/ernestas-poskus/ansible-prometheus/issues/41

This should solve the issue, let me know if other variables should escape [[ and ]] to {{ }}

cc @madeinoz67

Added additional test which checks whether alert manager variables are handled ([[ to {{).
Thus added additional validation with amtool.