### PR TITLE
Only create directories when prometheus is going to be installed.

### DIFF
--- a/tasks/install-alert_manager.yml
+++ b/tasks/install-alert_manager.yml
@@ -6,9 +6,9 @@
     state: directory
     owner: "{{ prometheus_owner }}"
     group: "{{ prometheus_group }}"
-    recurse: yes
     mode: 0750
   with_items:
+    - "{{ prometheus_config_dir }}"
     - "{{ prometheus_alert_manager_data_dir }}"
     - "{{ prometheus_alert_manager_config_dir }}"
     - "{{ prometheus_alert_manager_templates_dir }}"

--- a/tasks/install-alert_manager.yml
+++ b/tasks/install-alert_manager.yml
@@ -1,6 +1,6 @@
 - include_vars: 'alertmanager.yml'
 
-- name: "Creating alert manager directories"
+- name: Creating alert manager directories
   file:
     path: "{{ item }}"
     state: directory

--- a/tasks/install-alert_manager.yml
+++ b/tasks/install-alert_manager.yml
@@ -1,5 +1,18 @@
 - include_vars: 'alertmanager.yml'
 
+- name: "Creating directories"
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ prometheus_owner }}"
+    group: "{{ prometheus_group }}"
+    recurse: yes
+    mode: 0750
+  with_items:
+    - "{{ prometheus_alert_manager_data_dir }}"
+    - "{{ prometheus_alert_manager_config_dir }}"
+    - "{{ prometheus_alert_manager_templates_dir }}"
+
 - name: Download and extract Prometheus alertmanager tarball
   unarchive:
     src: "{{ prometheus_alert_manager_tarball_url }}"

--- a/tasks/install-alert_manager.yml
+++ b/tasks/install-alert_manager.yml
@@ -1,6 +1,6 @@
 - include_vars: 'alertmanager.yml'
 
-- name: "Creating directories"
+- name: "Creating alert manager directories"
   file:
     path: "{{ item }}"
     state: directory

--- a/tasks/install-alert_manager.yml
+++ b/tasks/install-alert_manager.yml
@@ -8,6 +8,7 @@
     group: "{{ prometheus_group }}"
     mode: 0750
   with_items:
+    - "{{ prometheus_lib_dir }}"
     - "{{ prometheus_config_dir }}"
     - "{{ prometheus_alert_manager_data_dir }}"
     - "{{ prometheus_alert_manager_config_dir }}"

--- a/tasks/install-blackbox_exporter.yml
+++ b/tasks/install-blackbox_exporter.yml
@@ -1,5 +1,16 @@
 - include_vars: 'blackboxexporter.yml'
 
+- name: "Creating directories"
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ prometheus_owner }}"
+    group: "{{ prometheus_group }}"
+    recurse: yes
+    mode: 0750
+  with_items:
+    - "{{ prometheus_blackbox_exporter_config_dir }}"
+
 - name: Download and extract Prometheus blackbox_exporter tarball
   unarchive:
     src: "{{ prometheus_blackbox_exporter_tarball_url }}"

--- a/tasks/install-blackbox_exporter.yml
+++ b/tasks/install-blackbox_exporter.yml
@@ -6,9 +6,9 @@
     state: directory
     owner: "{{ prometheus_owner }}"
     group: "{{ prometheus_group }}"
-    recurse: yes
     mode: 0750
   with_items:
+    - "{{ prometheus_config_dir }}"
     - "{{ prometheus_blackbox_exporter_config_dir }}"
 
 - name: Download and extract Prometheus blackbox_exporter tarball

--- a/tasks/install-blackbox_exporter.yml
+++ b/tasks/install-blackbox_exporter.yml
@@ -1,6 +1,6 @@
 - include_vars: 'blackboxexporter.yml'
 
-- name: "Creating directories"
+- name: "Creating blackbox exporter directories"
   file:
     path: "{{ item }}"
     state: directory

--- a/tasks/install-blackbox_exporter.yml
+++ b/tasks/install-blackbox_exporter.yml
@@ -1,6 +1,6 @@
 - include_vars: 'blackboxexporter.yml'
 
-- name: "Creating blackbox exporter directories"
+- name: Creating blackbox exporter directories
   file:
     path: "{{ item }}"
     state: directory

--- a/tasks/install-prometheus.yml
+++ b/tasks/install-prometheus.yml
@@ -1,6 +1,6 @@
 - include_vars: 'prometheus.yml'
 
-- name: "Creating Prometheus directories"
+- name: Creating Prometheus directories
   file:
     path: "{{ item }}"
     state: directory

--- a/tasks/install-prometheus.yml
+++ b/tasks/install-prometheus.yml
@@ -6,9 +6,9 @@
     state: directory
     owner: "{{ prometheus_owner }}"
     group: "{{ prometheus_group }}"
-    recurse: yes
     mode: 0750
   with_items:
+    - "{{ prometheus_config_dir }}"
     - "{{ prometheus_data_dir }}"
     - "{{ prometheus_lib_dir }}"
     - "{{ prometheus_rules_dir }}"

--- a/tasks/install-prometheus.yml
+++ b/tasks/install-prometheus.yml
@@ -1,5 +1,18 @@
 - include_vars: 'prometheus.yml'
 
+- name: "Creating directories"
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ prometheus_owner }}"
+    group: "{{ prometheus_group }}"
+    recurse: yes
+    mode: 0750
+  with_items:
+    - "{{ prometheus_data_dir }}"
+    - "{{ prometheus_lib_dir }}"
+    - "{{ prometheus_rules_dir }}"
+
 - name: Download and extract Prometheus tarball
   unarchive:
     src: "{{ prometheus_tarball_url }}"

--- a/tasks/install-prometheus.yml
+++ b/tasks/install-prometheus.yml
@@ -1,6 +1,6 @@
 - include_vars: 'prometheus.yml'
 
-- name: "Creating directories"
+- name: "Creating Prometheus directories"
   file:
     path: "{{ item }}"
     state: directory

--- a/tasks/install-snmp_exporter.yml
+++ b/tasks/install-snmp_exporter.yml
@@ -1,5 +1,16 @@
 - include_vars: 'snmpexporter.yml'
 
+- name: "Creating directories"
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ prometheus_owner }}"
+    group: "{{ prometheus_group }}"
+    recurse: yes
+    mode: 0750
+  with_items:
+    - "{{ prometheus_snmp_exporter_config_dir }}"
+
 - name: Download and extract Prometheus snmp_exporter tarball
   unarchive:
     src: "{{ prometheus_snmp_exporter_tarball_url }}"

--- a/tasks/install-snmp_exporter.yml
+++ b/tasks/install-snmp_exporter.yml
@@ -6,9 +6,9 @@
     state: directory
     owner: "{{ prometheus_owner }}"
     group: "{{ prometheus_group }}"
-    recurse: yes
     mode: 0750
   with_items:
+    - "{{ prometheus_config_dir }}"
     - "{{ prometheus_snmp_exporter_config_dir }}"
 
 - name: Download and extract Prometheus snmp_exporter tarball

--- a/tasks/install-snmp_exporter.yml
+++ b/tasks/install-snmp_exporter.yml
@@ -1,6 +1,6 @@
 - include_vars: 'snmpexporter.yml'
 
-- name: "Creating directories"
+- name: "Creating snmp exporter directories"
   file:
     path: "{{ item }}"
     state: directory

--- a/tasks/install-snmp_exporter.yml
+++ b/tasks/install-snmp_exporter.yml
@@ -1,6 +1,6 @@
 - include_vars: 'snmpexporter.yml'
 
-- name: "Creating snmp exporter directories"
+- name: Creating snmp exporter directories
   file:
     path: "{{ item }}"
     state: directory

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,25 +21,6 @@
     group: "root"
     mode: 0755
 
-- name: "Creating mkdir {{ item }}"
-  file:
-    path: "{{ item }}"
-    state: directory
-    owner: "{{ prometheus_owner }}"
-    group: "{{ prometheus_group }}"
-    mode: 0750
-  with_items:
-    - "{{ prometheus_config_dir }}"
-    - "{{ prometheus_data_dir }}"
-    - "{{ prometheus_lib_dir }}"
-    - "{{ prometheus_alert_manager_data_dir }}"
-    - "{{ prometheus_alert_manager_config_dir }}"
-    - "{{ prometheus_alert_manager_templates_dir }}"
-    - "{{ prometheus_rules_dir }}"
-    - "{{ prometheus_snmp_exporter_config_dir }}"
-    - "{{ prometheus_blackbox_exporter_config_dir }}"
-  when: prometheus_install
-
 - name: Install Prometheus
   include: install-prometheus.yml
   when: prometheus_install

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,6 +38,7 @@
     - "{{ prometheus_rules_dir }}"
     - "{{ prometheus_snmp_exporter_config_dir }}"
     - "{{ prometheus_blackbox_exporter_config_dir }}"
+  when: prometheus_install
 
 - name: Install Prometheus
   include: install-prometheus.yml


### PR DESCRIPTION
Only create directories when prometheus is going to be installed.
No need for them on a node_exporter only install