### PR TITLE
apply elevated privileges to blackbox_exporter for icmp probe

### DIFF
--- a/tasks/install-blackbox_exporter.yml
+++ b/tasks/install-blackbox_exporter.yml
@@ -29,6 +29,14 @@
   notify:
     - reload blackboxexporter
 
+- name: Apply elevated privileges to blackbox_exporter for ICMP probe
+  capabilities:
+    path: "{{ prometheus_install_dir }}/{{ prometheus_blackbox_exporter_archive }}/blackbox_exporter"
+    capability: cap_net_raw+ep
+    state: present
+  notify:
+    - reload blackboxexporter
+
 - name: Install Prometheus blackbox exporter systemd service
   template:
     src: blackbox_exporter.service.j2


### PR DESCRIPTION
As per blackbox_exporter documentation the executable requires elevated privileges for ICMP probe to work.

This PR applies the correct capabilities as outlined in the docs

> Permissions
> 
> The ICMP probe requires elevated privileges to function:
> 
> Windows: Administrator privileges are required.
> Linux: root user or CAP_NET_RAW capability is required.
> Can be set by executing setcap cap_net_raw+ep blackbox_exporter
> BSD / OS X: root user is required.