### PR TITLE
Bump prometheus to 2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ prometheus_snmp_exporter_config_dir: "{{ prometheus_config_dir }}/snmpexporter"
 prometheus_blackbox_exporter_config_dir: "{{ prometheus_config_dir }}/blackboxexporter"
 
 # Prometheus
-prometheus_version: '2.1.0'
+prometheus_version: '2.2.0'
 prometheus_platform_architecture: 'linux-amd64'
 
 # Node exporter

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,7 +24,7 @@ prometheus_snmp_exporter_config_dir: "{{ prometheus_config_dir }}/snmpexporter"
 prometheus_blackbox_exporter_config_dir: "{{ prometheus_config_dir }}/blackboxexporter"
 
 # Prometheus
-prometheus_version: '2.1.0'
+prometheus_version: '2.2.0'
 prometheus_platform_architecture: 'linux-amd64'
 
 # Node exporter


### PR DESCRIPTION
```
NOTE: This release introduces improvements to the storage format and fixes a regression introduced in 2.1. As a result Prometheus servers upgraded to 2.2 cannot be downgraded to a lower version anymore!
```
