### PR TITLE
Bump prometheus to 2.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ prometheus_snmp_exporter_config_dir: "{{ prometheus_config_dir }}/snmpexporter"
 prometheus_blackbox_exporter_config_dir: "{{ prometheus_config_dir }}/blackboxexporter"
 
 # Prometheus
-prometheus_version: '2.11.2'
+prometheus_version: '2.13.0'
 prometheus_platform_architecture: 'linux-amd64'
 
 # Node exporter

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,7 +24,7 @@ prometheus_snmp_exporter_config_dir: "{{ prometheus_config_dir }}/snmpexporter"
 prometheus_blackbox_exporter_config_dir: "{{ prometheus_config_dir }}/blackboxexporter"
 
 # Prometheus
-prometheus_version: '2.11.2'
+prometheus_version: '2.13.0'
 prometheus_platform_architecture: 'linux-amd64'
 
 # Node exporter
@@ -187,6 +187,13 @@ prometheus_storage__remote__read_concurrent_limit: 10
 # Maximum number of concurrent remote read calls.
 # 0 means no limit.
 
+prometheus_storage__remote__read_max_bytes_in_frame: 1048576
+# Maximum number of bytes in a single frame for
+# streaming remote read response types before
+# marshalling. Note that client might have limit
+# on frame size as well. 1MB as recommended by
+# protobuf by default.
+
 prometheus_storage__remote__read_sample_limit: '5e7'
 # Maximum overall number of samples to return via
 # the remote read interface, in a single query. 0 means no limit.
@@ -207,7 +214,9 @@ prometheus_log__level: 'info'
 
 # Prometheus flags
 prometheus____enabled_flags: []
+#  - 'storage.tsdb.allow-overlapping-blocks' # disabled by default
 #  - 'storage.tsdb.no-lockfile' # disabled by default
+#  - 'storage.tsdb.wal-compression' # disabled by default
 #  - 'web.enable-admin-api' # disabled by default
 #  - 'web.enable-lifecycle' # disabled by default
 #  - 'web.external-url.' # disabled by default

--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -146,6 +146,13 @@ prometheus_storage__remote__read_concurrent_limit: 10
 # Maximum number of concurrent remote read calls.
 # 0 means no limit.
 
+prometheus_storage__remote__read_max_bytes_in_frame: 1048576
+# Maximum number of bytes in a single frame for
+# streaming remote read response types before
+# marshalling. Note that client might have limit
+# on frame size as well. 1MB as recommended by
+# protobuf by default.
+
 prometheus_storage__remote__read_sample_limit: '5e7'
 # Maximum overall number of samples to return via
 # the remote read interface, in a single query. 0 means no limit.
@@ -166,7 +173,9 @@ prometheus_log__level: 'info'
 
 # Prometheus flags
 prometheus____enabled_flags: []
+#  - 'storage.tsdb.allow-overlapping-blocks' # disabled by default
 #  - 'storage.tsdb.no-lockfile' # disabled by default
+#  - 'storage.tsdb.wal-compression' # disabled by default
 #  - 'web.enable-admin-api' # disabled by default
 #  - 'web.enable-lifecycle' # disabled by default
 #  - 'web.external-url.' # disabled by default

--- a/vars/prometheus.yml
+++ b/vars/prometheus.yml
@@ -16,6 +16,7 @@ prometheus_service_config:
   - ['rules.alert.resend-delay', "{{ prometheus_rules__alert__resend_delay }}"]
   - ['storage.remote.flush-deadline', "{{ prometheus_storage__remote__flush_deadline }}"]
   - ['storage.remote.read-concurrent-limit', "{{ prometheus_storage__remote__read_concurrent_limit }}"]
+  - ['storage.remote.read-max-bytes-in-frame', "{{ prometheus_storage__remote__read_max_bytes_in_frame }}"]
   - ['storage.remote.read-sample-limit', "{{ prometheus_storage__remote__read_sample_limit }}"]
   - ['storage.tsdb.path', "{{ prometheus_storage__tsdb__path }}"]
   - ['storage.tsdb.retention.size', "{{ prometheus_storage__tsdb__retention__size }}"]


### PR DESCRIPTION
Bump prometheus to 2.13.0

New variables: 
```yaml
prometheus_storage__remote__read_max_bytes_in_frame: 1048576
# Maximum number of bytes in a single frame for
# streaming remote read response types before
# marshalling. Note that client might have limit
# on frame size as well. 1MB as recommended by
# protobuf by default.
```