### PR TITLE
Bump node exporter to 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ prometheus_version: '2.13.1'
 prometheus_platform_architecture: 'linux-amd64'
 
 # Node exporter
-prometheus_node_exporter_version: '0.18.1'
+prometheus_node_exporter_version: '1.0.1'
 
 # Alert manager
 prometheus_alert_manager_version: '0.18.0'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,7 +28,7 @@ prometheus_version: '2.13.1'
 prometheus_platform_architecture: 'linux-amd64'
 
 # Node exporter
-prometheus_node_exporter_version: '0.18.1'
+prometheus_node_exporter_version: '1.0.1'
 
 # Alert manager
 prometheus_alert_manager_version: '0.18.0'
@@ -232,7 +232,7 @@ prometheus_collector__netclass__ignored_devices: "^$"
 # Regexp of net devices to ignore for netclass collector.
 prometheus_collector__filesystem__ignored_mount_points: '^/(dev|proc|sys|var/lib/docker/.+)($|/)'
 # Regexp of mount points to ignore for filesystem
-prometheus_collector__netdev__ignored_devices: "^$"
+prometheus_collector__netdev__device_blacklist: "^$"
 # Regexp of net devices to ignore for netdev
 prometheus_collector__netstat__fields: "^(.*_(InErrors|InErrs)|Ip_Forwarding|Ip(6|Ext)_(InOctets|OutOctets)|Icmp6?_(InMsgs|OutMsgs)|TcpExt_(Listen.*|Syncookies.*|TCPSynRetrans)|Tcp_(ActiveOpens|InSegs|OutSegs|PassiveOpens|RetransSegs|CurrEstab)|Udp6?_(InDatagrams|OutDatagrams|NoPorts))$"
 # Regexp of fields to return for netstat collector.

--- a/docs/node_exporter.md
+++ b/docs/node_exporter.md
@@ -12,7 +12,7 @@ prometheus_collector__netclass__ignored_devices: "^$"
 # Regexp of net devices to ignore for netclass collector.
 prometheus_collector__filesystem__ignored_mount_points: '^/(dev|proc|sys|var/lib/docker/.+)($|/)'
 # Regexp of mount points to ignore for filesystem
-prometheus_collector__netdev__ignored_devices: "^$"
+prometheus_collector__netdev__device_blacklist: "^$"
 # Regexp of net devices to ignore for netdev
 prometheus_collector__netstat__fields: "^(.*_(InErrors|InErrs)|Ip_Forwarding|Ip(6|Ext)_(InOctets|OutOctets)|Icmp6?_(InMsgs|OutMsgs)|TcpExt_(Listen.*|Syncookies.*|TCPSynRetrans)|Tcp_(ActiveOpens|InSegs|OutSegs|PassiveOpens|RetransSegs|CurrEstab)|Udp6?_(InDatagrams|OutDatagrams|NoPorts))$"
 # Regexp of fields to return for netstat collector.

--- a/vars/nodeexporter.yml
+++ b/vars/nodeexporter.yml
@@ -6,7 +6,7 @@ prometheus_node_exporter_service_config:
   - ['collector.filesystem.ignored-mount-points', "{{ prometheus_collector__filesystem__ignored_mount_points }}"]
   - ['collector.filesystem.ignored-fs-types', "{{ prometheus_collector__filesystem__ignored_fs_types }}"]
   - ['collector.netclass.ignored-devices', "{{ prometheus_collector__netclass__ignored_devices }}"]
-  - ['collector.netdev.ignored-devices', "{{ prometheus_collector__netdev__ignored_devices }}"]
+  - ['collector.netdev.device-blacklist', "{{ prometheus_collector__netdev__device_blacklist }}"]
   - ['collector.netstat.fields', "{{ prometheus_collector__netstat__fields }}"]
   - ['collector.ntp.server', "{{ prometheus_collector__ntp__server }}"]
   - ['collector.ntp.protocol-version', "{{ prometheus_collector__ntp__protocol_version }}"]


### PR DESCRIPTION
Bumps node exporter version to 1.0.1 and renames deprecated CLI argument (see https://github.com/prometheus/node_exporter/blob/master/CHANGELOG.md#breaking-changes).