### PR TITLE
Add LimitNOFILE in prometheus.service

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ prometheus_snmp_exporter_version: '0.15.0'
 
 # Blackbox exporter
 prometheus_blackbox_exporter_version: '0.18.0'
+
+# Number of open file allowed, value for LimitNOFILE
+prometheus_service_limitnofile: infinity
 ```
 
 [DOCS: Prometheus variables](https://github.com/ernestas-poskus/ansible-prometheus/blob/master/docs/prometheus.md)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -520,3 +520,6 @@ prometheus_black_box_log__level: 'info'
 
 prometheus_black_box_config_modules:
 # Blackbox modules config in format of YAML
+
+# Number of open file allowed, value for LimitNOFILE
+prometheus_service_limitnofile: infinity

--- a/templates/prometheus.service.j2
+++ b/templates/prometheus.service.j2
@@ -16,6 +16,7 @@ Group={{prometheus_group}}
 StandardOutput=journal
 StandardError=journal
 WorkingDirectory={{ prometheus_install_dir }}/{{ prometheus_archive }}
+LimitNOFILE={{ prometheus_service_limitnofile }}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Recently, our Prometheus service stopped scrapping. Upon investigation, we found that Prometheus was logging the following error repeatedly -

```log
dial tcp 127.0.0.1:9093: socket: too many open files
```

Setting ``LimitNOFILE`` to ``infinity`` on the ``prometheus.service`` solved the issue for us. Since there is no way of setting that in this role, we've opened this PR.

This PR also includes a new configuration variable ``prometheus_service_limitnofile`` which can be used to set other values for ``LimitNOFILE`` other than ``infinity``.